### PR TITLE
Add model, evaluator and run_model tests (#111)

### DIFF
--- a/analysis_and_inference/evaluation_code/tests/test_evaluator.py
+++ b/analysis_and_inference/evaluation_code/tests/test_evaluator.py
@@ -53,6 +53,14 @@ class TestEvaluateClassification:
         y_pred = np.array([0, 0, 0, 0])
         evaluate_classification(y_true, y_pred, name="test")
 
+    def test_evaluator_all_zero_labels(self):
+        # covers the edge case where y_true has no positive class at all
+        y_true = np.array([0, 0, 0, 0, 0, 0])
+        y_pred = np.array([0, 1, 0, 1, 0, 1])
+        result = evaluate_classification(y_true, y_pred, name="test")
+        assert isinstance(result, dict)
+        assert result["recall"] == 0.0
+
 
 # ---------------------------------------------------------------------------
 # Model module resolution

--- a/analysis_and_inference/evaluation_code/tests/test_evaluator.py
+++ b/analysis_and_inference/evaluation_code/tests/test_evaluator.py
@@ -1,0 +1,67 @@
+import importlib
+
+import numpy as np
+import pytest
+
+from analysis_and_inference.evaluation_code.evaluator import evaluate_classification
+
+
+# ---------------------------------------------------------------------------
+# evaluate_classification
+# ---------------------------------------------------------------------------
+
+class TestEvaluateClassification:
+    def test_perfect_predictions_give_all_metrics_one(self):
+        # every metric collapses to 1.0 when there are no errors at all
+        y_true = np.array([0, 1, 0, 1, 0, 1])
+        y_pred = np.array([0, 1, 0, 1, 0, 1])
+        result = evaluate_classification(y_true, y_pred, name="test")
+        assert result["accuracy"] == 1.0
+        assert result["f1"] == 1.0
+        assert result["precision"] == 1.0
+        assert result["recall"] == 1.0
+
+    def test_return_dict_contains_expected_keys(self):
+        # downstream code indexes into these keys — missing one would break silently
+        y_true = np.array([0, 1, 0, 1])
+        y_pred = np.array([0, 1, 1, 0])
+        result = evaluate_classification(y_true, y_pred, name="test")
+        assert {"accuracy", "f1", "precision", "recall", "classification_report"}.issubset(result.keys())
+
+    def test_roc_pr_keys_absent_without_y_score(self):
+        # curve metrics require probability scores — they must not appear when only hard labels are given
+        y_true = np.array([0, 1, 0, 1])
+        y_pred = np.array([0, 1, 0, 1])
+        result = evaluate_classification(y_true, y_pred, name="test")
+        assert "roc_auc" not in result
+        assert "pr_auc" not in result
+
+    def test_roc_pr_keys_present_with_y_score(self):
+        # passing probability scores should unlock the curve metrics in the returned dict
+        y_true  = np.array([0, 1, 0, 1])
+        y_pred  = np.array([0, 1, 0, 1])
+        y_score = np.array([0.1, 0.9, 0.2, 0.8])
+        # plot_curves=False: new evaluator only writes files when save_dir is also set,
+        # but being explicit avoids any future change triggering file I/O in tests
+        result = evaluate_classification(y_true, y_pred, y_score, name="test", plot_curves=False)
+        assert "roc_auc" in result
+        assert "pr_auc" in result
+
+    def test_imbalanced_labels_do_not_crash(self):
+        # zero_division=0 should absorb the 0/0 precision when no positives are predicted
+        y_true = np.array([0, 0, 0, 1])
+        y_pred = np.array([0, 0, 0, 0])
+        evaluate_classification(y_true, y_pred, name="test")
+
+
+# ---------------------------------------------------------------------------
+# Model module resolution
+# (previously tested model_run registry; run_all.py replaced that pattern —
+#  models are now standalone modules, so an invalid name raises ModuleNotFoundError)
+# ---------------------------------------------------------------------------
+
+class TestModelRegistry:
+    def test_invalid_model_name_raises_module_not_found(self):
+        # a misspelled model slug should fail loudly at import rather than silently do nothing
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module("analysis_and_inference.models.nonexistent_model.nonexistent_model")

--- a/analysis_and_inference/models/baseline/tests/test_baseline.py
+++ b/analysis_and_inference/models/baseline/tests/test_baseline.py
@@ -13,6 +13,7 @@ Run with: uv run pytest test/test_baseline.py -v
 """
 
 import numpy as np
+from sklearn.datasets import make_classification
 from sklearn.dummy import DummyClassifier
 
 
@@ -28,3 +29,29 @@ def test_dummy_classifier_fits_and_predicts(tiny_data):
     proba = model.predict_proba(X)
     assert proba.shape == (len(y), 2)
     assert ((proba >= 0) & (proba <= 1)).all()
+
+
+def test_baseline_reproducibility_with_random_state():
+    # same random_state must produce identical predictions across two fits
+    X, y = make_classification(n_samples=50, n_features=5, random_state=42)
+
+    m1 = DummyClassifier(strategy="stratified", random_state=42)
+    m1.fit(X, y)
+
+    m2 = DummyClassifier(strategy="stratified", random_state=42)
+    m2.fit(X, y)
+
+    assert np.array_equal(m1.predict(X), m2.predict(X))
+
+
+def test_baseline_all_zero_labels():
+    # covers the edge case where the training set has no positive class at all
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.zeros(20, dtype=int)
+
+    model = DummyClassifier(strategy="stratified", random_state=42)
+    model.fit(X, y)
+
+    preds = model.predict(X)
+    assert len(preds) == 20

--- a/analysis_and_inference/models/ensemble/tests/test_ensemble.py
+++ b/analysis_and_inference/models/ensemble/tests/test_ensemble.py
@@ -48,3 +48,64 @@ def test_voting_classifier_prefit_hack(tiny_data):
     assert set(np.unique(preds)).issubset({0, 1})
     # Majority of (1, 0, 1) → 1 for every row
     assert (preds == 1).all()
+
+
+def test_ensemble_soft_voting_predict_proba(tiny_data):
+    # soft voting must expose predict_proba with valid probability values
+    X, y = tiny_data
+
+    m1 = DummyClassifier(strategy="constant", constant=1).fit(X, y)
+    m2 = DummyClassifier(strategy="constant", constant=0).fit(X, y)
+    m3 = DummyClassifier(strategy="constant", constant=1).fit(X, y)
+
+    members = [("a", m1), ("b", m2), ("c", m3)]
+    voter   = VotingClassifier(estimators=members, voting="soft")
+    voter.estimators_       = [m for _, m in members]
+    voter.named_estimators_ = dict(members)
+    voter.le_               = LabelEncoder().fit([0, 1])
+    voter.classes_          = voter.le_.classes_
+
+    proba = voter.predict_proba(X)
+    assert proba.shape == (len(y), 2)
+    assert ((proba >= 0) & (proba <= 1)).all()
+
+
+def test_ensemble_reproducibility(tiny_data):
+    # identical prefit members must produce identical predictions every time
+    X, y = tiny_data
+
+    def build_voter():
+        members = [
+            ("a", DummyClassifier(strategy="constant", constant=1).fit(X, y)),
+            ("b", DummyClassifier(strategy="constant", constant=1).fit(X, y)),
+            ("c", DummyClassifier(strategy="constant", constant=1).fit(X, y)),
+        ]
+        voter = VotingClassifier(estimators=members, voting="hard")
+        voter.estimators_       = [m for _, m in members]
+        voter.named_estimators_ = dict(members)
+        voter.le_               = LabelEncoder().fit([0, 1])
+        voter.classes_          = voter.le_.classes_
+        return voter
+
+    assert np.array_equal(build_voter().predict(X), build_voter().predict(X))
+
+
+def test_ensemble_all_zero_labels():
+    # covers the edge case where the training set has no positive class at all
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.zeros(20, dtype=int)
+
+    members = [
+        ("a", DummyClassifier(strategy="constant", constant=0).fit(X, y)),
+        ("b", DummyClassifier(strategy="constant", constant=0).fit(X, y)),
+        ("c", DummyClassifier(strategy="constant", constant=0).fit(X, y)),
+    ]
+    voter = VotingClassifier(estimators=members, voting="hard")
+    voter.estimators_       = [m for _, m in members]
+    voter.named_estimators_ = dict(members)
+    voter.le_               = LabelEncoder().fit([0, 1])
+    voter.classes_          = voter.le_.classes_
+
+    preds = voter.predict(X)
+    assert len(preds) == 20

--- a/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
+++ b/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
@@ -7,6 +7,7 @@ fits without errors, and produces valid predictions and probability scores.
 
 import numpy as np
 import pytest
+from sklearn.datasets import make_classification
 
 from analysis_and_inference.models._common import make_pipeline
 from analysis_and_inference.models.lasso_log_reg.core_logistic_regression_lasso import LassoLogisticRegression
@@ -82,26 +83,16 @@ class TestSigmoid:
 # Unit tests — _soft_threshold
 # ---------------------------------------------------------------------------
 
-class TestSoftThreshold:
-    def test_value_inside_threshold_becomes_zero(self, model):
-        # coefficients smaller than the penalty are killed completely — this is what makes Lasso sparse
-        assert model._soft_threshold(0.03, 0.05) == 0.0
-
-    def test_negative_value_inside_threshold_becomes_zero(self, model):
-        # sparsity applies symmetrically to negative coefficients
-        assert model._soft_threshold(-0.03, 0.05) == 0.0
-
-    def test_value_outside_threshold_shrinks_by_lambda(self, model):
-        # surviving coefficients are pulled toward zero by exactly lambda, not left unchanged
-        assert model._soft_threshold(0.8, 0.05) == pytest.approx(0.75)
-
-    def test_negative_value_outside_threshold_shrinks_by_lambda(self, model):
-        # shrinkage toward zero means a negative coefficient moves in the positive direction
-        assert model._soft_threshold(-0.8, 0.05) == pytest.approx(-0.75)
-
-    def test_sign_is_preserved(self, model):
-        # the penalty shrinks the weight but must never flip it to the wrong direction
-        assert model._soft_threshold(-0.9, 0.05) < 0
+# covers inside-threshold zeroing, outside-threshold shrinkage, sign preservation, and symmetry
+@pytest.mark.parametrize("value, threshold, expected", [
+    ( 0.03,  0.05,  0.0),
+    (-0.03,  0.05,  0.0),
+    ( 0.8,   0.05,  0.75),
+    (-0.8,   0.05, -0.75),
+    (-0.9,   0.05, -0.85),
+])
+def test_soft_threshold_parametrized(model, value, threshold, expected):
+    assert model._soft_threshold(value, threshold) == pytest.approx(expected)
 
 
 # ---------------------------------------------------------------------------
@@ -213,3 +204,21 @@ class TestConvergence:
         model.fit(X, y)
 
         assert model.n_iter_ < model.max_iter
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+
+def test_lasso_reproducibility_with_random_state():
+    # LassoLogisticRegression has no random_state — it is fully deterministic (gradient descent
+    # from fixed zero initialization), so two fits on identical data always produce equal predictions
+    X, y = make_classification(n_samples=50, n_features=5, random_state=42)
+
+    m1 = LassoLogisticRegression(alpha=0.01, max_iter=1000)
+    m1.fit(X, y)
+
+    m2 = LassoLogisticRegression(alpha=0.01, max_iter=1000)
+    m2.fit(X, y)
+
+    assert np.array_equal(m1.predict(X), m2.predict(X))

--- a/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
+++ b/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
@@ -6,6 +6,7 @@ fits without errors, and produces valid predictions and probability scores.
 """
 
 import numpy as np
+import pytest
 
 from analysis_and_inference.models._common import make_pipeline
 from analysis_and_inference.models.lasso_log_reg.core_logistic_regression_lasso import LassoLogisticRegression
@@ -23,3 +24,188 @@ def test_lasso_pipeline_fits_and_predicts(tiny_data):
     proba = pipe.predict_proba(X)
     assert proba.shape == (len(y), 2)
     assert ((proba >= 0) & (proba <= 1)).all()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for unit tests below (raw numpy arrays, independent of tiny_data)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def model():
+    return LassoLogisticRegression()
+
+
+@pytest.fixture
+def fitted_model():
+    rng = np.random.default_rng(1)
+    X = rng.standard_normal((50, 4))
+    y = (X[:, 0] > 0).astype(int)
+    m = LassoLogisticRegression(alpha=0.01, max_iter=500)
+    m.fit(X, y)
+    return m, X
+
+
+@pytest.fixture
+def sparse_data():
+    # 200 samples, 20 features — only the first two actually predict y
+    rng = np.random.default_rng(42)
+    n, p = 200, 20
+    X = rng.standard_normal((n, p))
+    y = (X[:, 0] - X[:, 1] > 0).astype(int)
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _sigmoid
+# ---------------------------------------------------------------------------
+
+class TestSigmoid:
+    def test_zero_input_returns_half(self, model):
+        # zero is the symmetry point — neither class is favoured
+        assert model._sigmoid(0) == pytest.approx(0.5)
+
+    def test_large_positive_approaches_one(self, model):
+        # strong positive signal should mean near-certain class 1
+        assert model._sigmoid(100) == pytest.approx(1.0, abs=1e-6)
+
+    def test_large_negative_approaches_zero(self, model):
+        # strong negative signal should mean near-certain class 0
+        assert model._sigmoid(-100) == pytest.approx(0.0, abs=1e-6)
+
+    def test_clip_prevents_overflow(self, model):
+        # values beyond ±500 are clipped — result should still be a valid float, not nan
+        result = model._sigmoid(1e9)
+        assert np.isfinite(result)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _soft_threshold
+# ---------------------------------------------------------------------------
+
+class TestSoftThreshold:
+    def test_value_inside_threshold_becomes_zero(self, model):
+        # coefficients smaller than the penalty are killed completely — this is what makes Lasso sparse
+        assert model._soft_threshold(0.03, 0.05) == 0.0
+
+    def test_negative_value_inside_threshold_becomes_zero(self, model):
+        # sparsity applies symmetrically to negative coefficients
+        assert model._soft_threshold(-0.03, 0.05) == 0.0
+
+    def test_value_outside_threshold_shrinks_by_lambda(self, model):
+        # surviving coefficients are pulled toward zero by exactly lambda, not left unchanged
+        assert model._soft_threshold(0.8, 0.05) == pytest.approx(0.75)
+
+    def test_negative_value_outside_threshold_shrinks_by_lambda(self, model):
+        # shrinkage toward zero means a negative coefficient moves in the positive direction
+        assert model._soft_threshold(-0.8, 0.05) == pytest.approx(-0.75)
+
+    def test_sign_is_preserved(self, model):
+        # the penalty shrinks the weight but must never flip it to the wrong direction
+        assert model._soft_threshold(-0.9, 0.05) < 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — sparsity
+# ---------------------------------------------------------------------------
+
+class TestSparsity:
+    def test_high_alpha_zeros_most_coefficients(self, sparse_data):
+        # strong regularization should drive noise features to exactly zero
+        X, y = sparse_data
+        model = LassoLogisticRegression(alpha=1.0, max_iter=1000)
+        model.fit(X, y)
+        assert np.sum(model.coef_ == 0) > len(model.coef_) // 2
+
+    def test_zero_alpha_produces_fewer_zeros_than_high_alpha(self, sparse_data):
+        # without a penalty there is no pressure to zero anything out
+        X, y = sparse_data
+        model_low  = LassoLogisticRegression(alpha=0.0, max_iter=1000)
+        model_high = LassoLogisticRegression(alpha=1.0, max_iter=1000)
+        model_low.fit(X, y)
+        model_high.fit(X, y)
+        assert np.sum(model_low.coef_ == 0) < np.sum(model_high.coef_ == 0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — predictions
+# ---------------------------------------------------------------------------
+
+class TestPredictions:
+    def test_predict_proba_shape(self, fitted_model):
+        # one probability pair per sample — (n, 2) is the sklearn contract
+        m, X = fitted_model
+        assert m.predict_proba(X).shape == (len(X), 2)
+
+    def test_predict_proba_values_in_range(self, fitted_model):
+        # every value must be a valid probability — nothing below 0 or above 1
+        m, X = fitted_model
+        proba = m.predict_proba(X)
+        assert np.all(proba >= 0) and np.all(proba <= 1)
+
+    def test_predict_proba_rows_sum_to_one(self, fitted_model):
+        # the two columns are complements — P(class 0) + P(class 1) must equal 1
+        m, X = fitted_model
+        row_sums = m.predict_proba(X).sum(axis=1)
+        assert row_sums == pytest.approx(np.ones(len(X)))
+
+    def test_predict_returns_binary(self, fitted_model):
+        # a binary classifier must only ever output 0 or 1, nothing in between
+        m, X = fitted_model
+        assert set(m.predict(X)).issubset({0, 1})
+
+    def test_threshold_zero_predicts_all_ones(self, fitted_model):
+        # sigmoid output is always strictly > 0, so every sample clears a threshold of 0
+        m, X = fitted_model
+        assert np.all(m.predict(X, threshold=0.0) == 1)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — score
+# ---------------------------------------------------------------------------
+
+class TestScore:
+    def test_perfect_accuracy_on_separable_data(self):
+        # a wide decision boundary leaves no room for misclassification
+        rng = np.random.default_rng(7)
+        n = 100
+        X = rng.standard_normal((n, 4))
+        X[:n // 2, 0] += 10
+        X[n // 2:, 0] -= 10
+        y = np.array([1] * (n // 2) + [0] * (n // 2))
+
+        model = LassoLogisticRegression(alpha=0.01, max_iter=1000)
+        model.fit(X, y)
+        assert model.score(X, y) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — intercept
+# ---------------------------------------------------------------------------
+
+class TestIntercept:
+    def test_fit_intercept_false_keeps_intercept_at_zero(self, sparse_data):
+        # the flag must suppress intercept updates, not just initialise to zero
+        X, y = sparse_data
+        model = LassoLogisticRegression(fit_intercept=False, max_iter=500)
+        model.fit(X, y)
+        assert model.intercept_ == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — convergence
+# ---------------------------------------------------------------------------
+
+class TestConvergence:
+    def test_converges_before_max_iter_on_separable_data(self, capsys):
+        # a large-margin dataset should let gradient descent stabilise long before the iteration cap
+        rng = np.random.default_rng(0)
+        n = 100
+        X = rng.standard_normal((n, 5))
+        X[:n // 2, 0] += 10   # class 1 is far positive on feature 0
+        X[n // 2:, 0] -= 10   # class 0 is far negative on feature 0
+        y = np.array([1] * (n // 2) + [0] * (n // 2))
+
+        model = LassoLogisticRegression(alpha=0.01, max_iter=1000, tol=1e-4)
+        model.fit(X, y)
+
+        assert "converged at iteration" in capsys.readouterr().out

--- a/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
+++ b/analysis_and_inference/models/lasso_log_reg/tests/test_lasso.py
@@ -153,10 +153,14 @@ class TestPredictions:
         m, X = fitted_model
         assert set(m.predict(X)).issubset({0, 1})
 
-    def test_threshold_zero_predicts_all_ones(self, fitted_model):
-        # sigmoid output is always strictly > 0, so every sample clears a threshold of 0
-        m, X = fitted_model
-        assert np.all(m.predict(X, threshold=0.0) == 1)
+    def test_threshold_zero_predicts_all_ones(self):
+        # sigmoid is always > 0, so decision_threshold=0.0 forces every prediction to 1
+        rng = np.random.default_rng(1)
+        X = rng.standard_normal((50, 4))
+        y = (X[:, 0] > 0).astype(int)
+        m = LassoLogisticRegression(alpha=0.01, max_iter=500, decision_threshold=0.0)
+        m.fit(X, y)
+        assert np.all(m.predict(X) == 1)
 
 
 # ---------------------------------------------------------------------------
@@ -196,8 +200,8 @@ class TestIntercept:
 # ---------------------------------------------------------------------------
 
 class TestConvergence:
-    def test_converges_before_max_iter_on_separable_data(self, capsys):
-        # a large-margin dataset should let gradient descent stabilise long before the iteration cap
+    def test_converges_before_max_iter_on_separable_data(self):
+        # the model stores n_iter_ after fitting — on separable data it should be well under max_iter
         rng = np.random.default_rng(0)
         n = 100
         X = rng.standard_normal((n, 5))
@@ -208,4 +212,4 @@ class TestConvergence:
         model = LassoLogisticRegression(alpha=0.01, max_iter=1000, tol=1e-4)
         model.fit(X, y)
 
-        assert "converged at iteration" in capsys.readouterr().out
+        assert model.n_iter_ < model.max_iter

--- a/analysis_and_inference/models/random_forest/tests/test_random_forest.py
+++ b/analysis_and_inference/models/random_forest/tests/test_random_forest.py
@@ -7,6 +7,7 @@ fits successfully, and produces valid predictions and probability outputs.
 """
 
 import numpy as np
+from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier
 
 from analysis_and_inference.models._common import make_pipeline
@@ -26,3 +27,28 @@ def test_random_forest_pipeline_fits_and_predicts(tiny_data):
     proba = pipe.predict_proba(X)
     assert proba.shape == (len(y), 2)
     assert ((proba >= 0) & (proba <= 1)).all()
+
+
+def test_random_forest_reproducibility():
+    # same random_state must produce identical predictions across two fits on the same data
+    X, y = make_classification(n_samples=50, n_features=5, random_state=42)
+
+    def build_and_fit():
+        pipe = make_pipeline(RandomForestClassifier(n_estimators=10, random_state=42, n_jobs=1, class_weight="balanced"))
+        pipe.fit(X, y)
+        return pipe
+
+    assert np.array_equal(build_and_fit().predict(X), build_and_fit().predict(X))
+
+
+def test_random_forest_all_zero_labels():
+    # covers the edge case where the training set has no positive class at all
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.zeros(20, dtype=int)
+
+    pipe = make_pipeline(RandomForestClassifier(n_estimators=10, random_state=42, n_jobs=1, class_weight="balanced"))
+    pipe.fit(X, y)
+
+    preds = pipe.predict(X)
+    assert len(preds) == 20

--- a/analysis_and_inference/models/ridge_log_reg/tests/test_ridge.py
+++ b/analysis_and_inference/models/ridge_log_reg/tests/test_ridge.py
@@ -7,6 +7,7 @@ fits successfully, and produces valid predictions and probability outputs.
 """
 
 import numpy as np
+from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 
 from analysis_and_inference.models._common import make_pipeline
@@ -27,3 +28,31 @@ def test_ridge_pipeline_fits_and_predicts(tiny_data):
     proba = pipe.predict_proba(X)
     assert proba.shape == (len(y), 2)
     assert ((proba >= 0) & (proba <= 1)).all()
+
+
+def test_ridge_reproducibility():
+    # same random_state must produce identical predictions across two fits on the same data
+    X, y = make_classification(n_samples=50, n_features=5, random_state=42)
+
+    def build_and_fit():
+        pipe = make_pipeline(LogisticRegression(
+            penalty="l2", solver="lbfgs", class_weight="balanced", max_iter=200, random_state=42,
+        ))
+        pipe.fit(X, y)
+        return pipe
+
+    assert np.array_equal(build_and_fit().predict(X), build_and_fit().predict(X))
+
+
+def test_ridge_all_zero_labels():
+    # LogisticRegression requires at least 2 classes — single-class input must raise ValueError
+    import pytest
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.zeros(20, dtype=int)
+
+    pipe = make_pipeline(LogisticRegression(
+        penalty="l2", solver="lbfgs", class_weight="balanced", max_iter=200, random_state=42,
+    ))
+    with pytest.raises(ValueError, match="at least 2 classes"):
+        pipe.fit(X, y)

--- a/analysis_and_inference/models/svm/tests/test_svm.py
+++ b/analysis_and_inference/models/svm/tests/test_svm.py
@@ -11,6 +11,8 @@ LinearSVC does not provide calibrated class probabilities.
 """
 
 import numpy as np
+import pytest
+from sklearn.datasets import make_classification
 from sklearn.svm import LinearSVC
 
 from analysis_and_inference.models._common import make_pipeline
@@ -30,3 +32,26 @@ def test_svm_pipeline_fits_and_predicts(tiny_data):
     # LinearSVC has no predict_proba, but decision_function should produce a 1D score array
     scores = pipe.decision_function(X)
     assert scores.shape == (len(y),)
+
+
+def test_svm_reproducibility():
+    # same random_state must produce identical predictions across two fits on the same data
+    X, y = make_classification(n_samples=50, n_features=5, random_state=42)
+
+    def build_and_fit():
+        pipe = make_pipeline(LinearSVC(class_weight="balanced", random_state=42, max_iter=500))
+        pipe.fit(X, y)
+        return pipe
+
+    assert np.array_equal(build_and_fit().predict(X), build_and_fit().predict(X))
+
+
+def test_svm_all_zero_labels():
+    # LinearSVC requires at least 2 classes — single-class input must raise ValueError
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = np.zeros(20, dtype=int)
+
+    pipe = make_pipeline(LinearSVC(class_weight="balanced", random_state=42, max_iter=500))
+    with pytest.raises(ValueError):
+        pipe.fit(X, y)

--- a/analysis_and_inference/models/tests/run_tests.py
+++ b/analysis_and_inference/models/tests/run_tests.py
@@ -1,0 +1,28 @@
+"""Master test runner: unit tests, integration tests, and end-to-end discovery across all model folders."""
+
+import sys
+import pytest
+
+
+def main():
+    # per-model unit test folders
+    model_test_dirs = [
+        "analysis_and_inference/models/baseline/tests",
+        "analysis_and_inference/models/ensemble/tests",
+        "analysis_and_inference/models/lasso_log_reg/tests",
+        "analysis_and_inference/models/random_forest/tests",
+        "analysis_and_inference/models/ridge_log_reg/tests",
+        "analysis_and_inference/models/svm/tests",
+    ]
+
+    # integration and evaluator tests
+    integration_dir = "analysis_and_inference/models/tests"
+    evaluator_dir   = "analysis_and_inference/evaluation_code/tests"
+
+    # run everything in one pytest invocation
+    args = model_test_dirs + [integration_dir, evaluator_dir, "-v"]
+    sys.exit(pytest.main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis_and_inference/models/tests/test_integration.py
+++ b/analysis_and_inference/models/tests/test_integration.py
@@ -1,0 +1,63 @@
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.svm import LinearSVC
+
+from analysis_and_inference.models._common import make_pipeline
+from analysis_and_inference.evaluation_code.evaluator import evaluate_classification
+
+
+def make_synthetic_data():
+    # synthetic numeric data mimicking precompute_features output
+    X, y = make_classification(n_samples=100, n_features=10, random_state=42)
+    return X[:80], X[80:], y[:80], y[80:]
+
+
+def test_random_forest_pipeline_to_evaluator():
+    # full chain from pipeline to evaluator with probability scores
+    X_train, X_test, y_train, y_test = make_synthetic_data()
+
+    pipe = make_pipeline(RandomForestClassifier(n_estimators=10, random_state=42, n_jobs=1, class_weight="balanced"))
+    pipe.fit(X_train, y_train)
+
+    y_pred  = pipe.predict(X_test)
+    y_score = pipe.predict_proba(X_test)[:, 1]
+
+    result = evaluate_classification(y_test, y_pred, y_score=y_score, name="RF Integration", plot_curves=False, save_dir=None)
+
+    assert isinstance(result, dict)
+    assert {"accuracy", "f1", "precision", "recall", "roc_auc", "pr_auc"}.issubset(result.keys())
+    assert all(0.0 <= result[k] <= 1.0 for k in ("accuracy", "f1", "precision", "recall", "roc_auc", "pr_auc"))
+
+
+def test_svm_pipeline_to_evaluator():
+    # integration with decision_function instead of predict_proba
+    X_train, X_test, y_train, y_test = make_synthetic_data()
+
+    pipe = make_pipeline(LinearSVC(class_weight="balanced", random_state=42, max_iter=500))
+    pipe.fit(X_train, y_train)
+
+    y_pred  = pipe.predict(X_test)
+    y_score = pipe.decision_function(X_test)
+
+    result = evaluate_classification(y_test, y_pred, y_score=y_score, name="SVM Integration", plot_curves=False, save_dir=None)
+
+    assert isinstance(result, dict)
+    assert {"accuracy", "f1", "precision", "recall"}.issubset(result.keys())
+
+
+def test_ridge_pipeline_to_evaluator_no_scores():
+    # evaluator without probability scores should still return base metrics
+    X_train, X_test, y_train, y_test = make_synthetic_data()
+
+    pipe = make_pipeline(LogisticRegression(solver="lbfgs", class_weight="balanced", max_iter=200, random_state=42))
+    pipe.fit(X_train, y_train)
+
+    y_pred = pipe.predict(X_test)
+
+    result = evaluate_classification(y_test, y_pred, y_score=None, name="Ridge Integration", plot_curves=False, save_dir=None)
+
+    assert isinstance(result, dict)
+    assert {"accuracy", "f1", "precision", "recall"}.issubset(result.keys())
+    assert "roc_auc" not in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
     "pytest>=9.0.2",
 ]
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
 # BERT embeddings are optional — large download (~2GB), only needed if
 # BertTransformer is used. Install manually if needed:
 #   uv add torch transformers


### PR DESCRIPTION
This PR adds 25 tests to test_models.py. **All 25 pass.**

**Sigmoid (4 tests):** 
Checks that the sigmoid function returns 0.5 at zero, approaches 1 for large positive inputs, approaches 0 for large negative inputs, and handles extreme values without crashing.

**Soft threshold (5 tests):**
Checks that coefficients smaller than the penalty are zeroed out, coefficients larger than the penalty are shrunk by exactly the penalty amount, and the sign of the coefficient is preserved.

**Sparsity (2 tests):**
Checks that a high regularization penalty drives most coefficients to zero, and that removing the penalty produces fewer zeros.

**Convergence (1 test):**
Checks that the model stops training early on clearly separable data instead of running all iterations.

**Predictions (5 tests):**
Checks that predict_proba outputs the right shape, valid probabilities between 0 and 1 that sum to 1 per row, that predict returns only 0s and 1s, and that the threshold parameter works.

**Intercept (1 test):**
Checks that fit_intercept=False keeps the intercept at zero after training.

**Score (1 test):**
Checks that the model achieves perfect accuracy on clearly separable data.

**Evaluator (5 tests):**
Checks that perfect predictions return all metrics at 1.0, the output contains all expected keys, ROC-AUC and PR-AUC keys only appear when probability scores are provided, and imbalanced labels don't cause a crash.

**Run model (1 test):**
Checks that passing an invalid model name raises a clear error.

Also adds pythonpath = ["."] to pyproject.toml so pytest can find the analysis package.